### PR TITLE
Pass -fPIC option directly to configure

### DIFF
--- a/doc/INSTALL_Linux.md
+++ b/doc/INSTALL_Linux.md
@@ -58,20 +58,7 @@ $ cd ..
 ### gridutils
 ```
 $ cd gridutils
-$ ./configure
-```
-
-Edit the `makefile` and change this (line ~31):
-
-`CFLAGS = -g -O2 -Wall -pedantic`
-
-To this:
-
-`CFLAGS = -g -O2 -Wall -pedantic -fPIC`
-
-After doing this, do *not* run `./configure` again
-
-```
+$ ./configure CFLAGS="-g -O2 -Wall -pedantic -fPIC"
 $ sudo make install
 $ cd ..
 ```


### PR DESCRIPTION
Hello,

I found an easy way to pass -fPIC option to makefile without modifying it after running ./configure.
Tested on Ubuntu 14.04, gcc 4.8.4.

Kenno